### PR TITLE
Convert from 1d to 2d coordinates

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "A data structure to track logical text annotations.",
   "main": "dist/marker-index.js",
   "scripts": {
-    "test": "npm run standard && node_modules/.bin/mocha --recursive ./test/helpers/setup  test",
-    "tdd": "npm run standard && node_modules/.bin/electron-mocha --renderer --interactive --recursive ./test/helpers/setup  test",
+    "test": "npm run standard && node_modules/.bin/mocha --recursive ./test/helpers/setup  test/marker-index.test.js",
+    "tdd": "npm run standard && node_modules/.bin/electron-mocha --renderer --interactive --recursive ./test/helpers/setup  test/marker-index.test.js",
+    "profile": "npm run standard && node_modules/.bin/electron-mocha --renderer --interactive --recursive ./test/helpers/setup  test/marker-index.profile.js",
     "prepublish": "npm run standard && npm run clean && npm run build",
     "standard": "node_modules/.bin/standard --recursive src test",
     "build": "node_modules/.bin/babel src --out-dir dist",

--- a/src/node.js
+++ b/src/node.js
@@ -1,5 +1,3 @@
-let idCounter = 1
-
 export default class Node {
   constructor (parent, leftExtent) {
     this.parent = parent
@@ -11,10 +9,12 @@ export default class Node {
     this.startMarkerIds = new Set()
     this.endMarkerIds = new Set()
     this.priority = null
-    this.id = idCounter++
+    this.id = this.constructor.idCounter++
   }
 
   isMarkerEndpoint () {
     return (this.startMarkerIds.size + this.endMarkerIds.size) > 0
   }
 }
+
+Node.idCounter = 1

--- a/src/point-helpers.js
+++ b/src/point-helpers.js
@@ -1,0 +1,53 @@
+export function traverse (start, traversal) {
+  if (traversal.row === 0) {
+    return {
+      row: start.row,
+      column: start.column + traversal.column
+    }
+  } else {
+    return {
+      row: start.row + traversal.row,
+      column: traversal.column
+    }
+  }
+}
+
+export function traversal (end, start) {
+  if (end.row === start.row) {
+    return {row: 0, column: end.column - start.column}
+  } else {
+    return {row: end.row - start.row, column: end.column}
+  }
+}
+
+export function compare (a, b) {
+  if (a.row < b.row) {
+    return -1
+  } else if (a.row > b.row) {
+    return 1
+  } else {
+    if (a.column < b.column) {
+      return -1
+    } else if (a.column > b.column) {
+      return 1
+    } else {
+      return 0
+    }
+  }
+}
+
+export function max (a, b) {
+  if (compare(a, b) > 0) {
+    return a
+  } else {
+    return b
+  }
+}
+
+export function isZero (point) {
+  return point.row === 0 && point.column === 0
+}
+
+export function format (point) {
+  return `(${point.row}, ${point.column})`
+}

--- a/test/helpers/add-to-html-methods.js
+++ b/test/helpers/add-to-html-methods.js
@@ -1,5 +1,6 @@
 import MarkerIndex from '../../src/marker-index'
 import Node from '../../src/node'
+import {traverse, format as formatPoint} from '../../src/point-helpers'
 
 MarkerIndex.prototype.toHTML = function () {
   if (!this.root) return ''
@@ -8,12 +9,12 @@ MarkerIndex.prototype.toHTML = function () {
   s += 'table { width: 100%; }'
   s += 'td { width: 50%; text-align: center; border: 1px solid gray; white-space: nowrap; }'
   s += '</style>'
-  s += this.root.toHTML(0)
+  s += this.root.toHTML({row: 0, column: 0})
   return s
 }
 
 Node.prototype.toHTML = function (leftAncestorOffset) {
-  let offset = leftAncestorOffset + this.leftExtent
+  let offset = traverse(leftAncestorOffset, this.leftExtent)
 
   let s = ''
   s += '<table>'
@@ -23,17 +24,15 @@ Node.prototype.toHTML = function (leftAncestorOffset) {
   for (let id of this.leftMarkerIds) {
     s += id + ' '
   }
-  s += '<< '
+  s += '[ '
   for (let id of this.endMarkerIds) {
     s += id + ' '
   }
-  s += '(( '
-  s += offset
-  s += ' ))'
+  s += formatPoint(offset)
   for (let id of this.startMarkerIds) {
     s += ' ' + id
   }
-  s += ' >>'
+  s += ' ]'
   for (let id of this.rightMarkerIds) {
     s += ' ' + id
   }

--- a/test/marker-index.profile.js
+++ b/test/marker-index.profile.js
@@ -1,0 +1,77 @@
+import Random from 'random-seed'
+import MarkerIndex from '../src/marker-index'
+import {traverse, traversal, compare} from '../src/point-helpers'
+
+describe('MarkerIndex', () => {
+  it('profile random insertion', function () {
+    let random = new Random(1)
+    let operations = []
+    let markerIds = []
+    let idCounter = 1
+
+    for (let i = 0; i < 10000; i++) {
+      let n = random(10)
+      if (n >= 4) { // 60% insert
+        enqueueInsert()
+      } else if (n >= 2) { // 20% splice
+        enqueueSplice()
+      } else if (markerIds.length > 0) { // 20% delete
+        enqueueDelete()
+      }
+    }
+
+    let markerIndex = new MarkerIndex()
+
+    console.profile()
+    console.time('operations')
+    for (let [method, args] of operations) {
+      markerIndex[method](...args)
+    }
+    console.profileEnd()
+    console.timeEnd('operations')
+
+    function enqueueInsert () {
+      let id = String.fromCharCode(idCounter++)
+      let [start, end] = getRange()
+      let exclusive = Boolean(random(2))
+      markerIds.push(id)
+      operations.push(['insert', [id, start, end]])
+      operations.push(['setExclusive', [id, exclusive]])
+    }
+
+    function enqueueSplice () {
+      operations.push(['splice', getSplice()])
+    }
+
+    function enqueueDelete () {
+      let id = markerIds.splice(random(markerIds.length), 1)
+      operations.push(['delete', [id]])
+    }
+
+    function getRange () {
+      let start = {row: random(100), column: random(100)}
+      let end = start
+      while (random(3) > 0) {
+        end = traverse(end, {row: random.intBetween(-10, 10), column: random.intBetween(-10, 10)})
+      }
+      end.row = Math.max(end.row, 0)
+      end.column = Math.max(end.column, 0)
+
+      if (compare(start, end) <= 0) {
+        return [start, end]
+      } else {
+        return [end, start]
+      }
+    }
+
+    function getSplice () {
+      let [start, oldEnd] = getRange()
+      let oldExtent = traversal(oldEnd, start)
+      let newExtent = {row: 0, column: 0}
+      while (random(2)) {
+        newExtent = traverse(newExtent, {row: random(10), column: random(10)})
+      }
+      return [start, oldExtent, newExtent]
+    }
+  })
+})


### PR DESCRIPTION
Since most operations in Atom’s text-buffer are in terms of row/column coordinates, it ends up being more efficient to maintain the marker index in terms of rows and columns rather than requiring translation from character offsets to read marker ranges. However, point arithmetic is much more expensive than integer arithmetic, so there are trade-offs. I'd like to explore dropping this to C++, which has better facilities for dealing with value objects like points efficiently.