### PR TITLE
Fix surround/overlap invalidation for exclusive markers

### DIFF
--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -152,22 +152,54 @@ export default class MarkerIndex {
         }
       })
     } else {
-      this.getMarkersBetweenNodes(startNode, endNode, startingInsideSplice, endingInsideSplice)
+      this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
 
       startingInsideSplice.forEach(markerId => {
-        startNode.startMarkerIds.delete(markerId)
-        startNode.rightMarkerIds.delete(markerId)
         endNode.startMarkerIds.add(markerId)
         this.startNodesById[markerId] = endNode
+        if (this.isExclusive(markerId) && endNode.endMarkerIds.has(markerId)) {
+          endingInsideSplice.add(markerId)
+        }
       })
 
       endingInsideSplice.forEach(markerId => {
-        startNode.endMarkerIds.delete(markerId)
         endNode.endMarkerIds.add(markerId)
         if (!startingInsideSplice.has(markerId)) {
           startNode.rightMarkerIds.add(markerId)
         }
         this.endNodesById[markerId] = endNode
+      })
+
+      startNode.startMarkerIds.forEach(markerId => {
+        if (this.isExclusive(markerId) && !startNode.endMarkerIds.has(markerId)) {
+          startNode.startMarkerIds.delete(markerId)
+          startNode.rightMarkerIds.delete(markerId)
+          endNode.startMarkerIds.add(markerId)
+          this.startNodesById[markerId] = endNode
+          startingInsideSplice.add(markerId)
+        }
+      })
+
+      endNode.startMarkerIds.forEach(markerId => {
+        if (!this.isExclusive(markerId)) {
+          startingInsideSplice.add(markerId)
+        }
+      })
+
+      startNode.endMarkerIds.forEach(markerId => {
+        if (!this.isExclusive(markerId)) {
+          startNode.endMarkerIds.delete(markerId)
+          endNode.endMarkerIds.add(markerId)
+          startNode.rightMarkerIds.add(markerId)
+          this.endNodesById[markerId] = endNode
+          endingInsideSplice.add(markerId)
+        }
+      })
+
+      endNode.endMarkerIds.forEach(markerId => {
+        if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
+          endingInsideSplice.add(markerId)
+        }
       })
     }
 
@@ -383,34 +415,6 @@ export default class MarkerIndex {
         root.leftMarkerIds.add(markerId)
       }
     })
-  }
-
-  getMarkersBetweenNodes (startNode, endNode, startingInsideSplice, endingInsideSplice) {
-    startNode.startMarkerIds.forEach(markerId => {
-      if (this.isExclusive(markerId) && !startNode.endMarkerIds.has(markerId)) {
-        startingInsideSplice.add(markerId)
-      }
-    })
-
-    endNode.startMarkerIds.forEach(markerId => {
-      if (!this.isExclusive(markerId)) {
-        startingInsideSplice.add(markerId)
-      }
-    })
-
-    startNode.endMarkerIds.forEach(markerId => {
-      if (!this.isExclusive(markerId)) {
-        endingInsideSplice.add(markerId)
-      }
-    })
-
-    endNode.endMarkerIds.forEach(markerId => {
-      if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
-        endingInsideSplice.add(markerId)
-      }
-    })
-
-    this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
   }
 
   getStartingAndEndingMarkersWithinSubtree (node, startMarkerIds, endMarkerIds) {

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -385,32 +385,32 @@ export default class MarkerIndex {
     })
   }
 
-  getMarkersBetweenNodes (startNode, endNode, startingInside, endingInside) {
+  getMarkersBetweenNodes (startNode, endNode, startingInsideSplice, endingInsideSplice) {
     startNode.startMarkerIds.forEach(markerId => {
       if (this.isExclusive(markerId) && !startNode.endMarkerIds.has(markerId)) {
-        startingInside.add(markerId)
+        startingInsideSplice.add(markerId)
       }
     })
 
     endNode.startMarkerIds.forEach(markerId => {
       if (!this.isExclusive(markerId)) {
-        startingInside.add(markerId)
+        startingInsideSplice.add(markerId)
       }
     })
 
     startNode.endMarkerIds.forEach(markerId => {
       if (!this.isExclusive(markerId)) {
-        endingInside.add(markerId)
+        endingInsideSplice.add(markerId)
       }
     })
 
     endNode.endMarkerIds.forEach(markerId => {
       if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
-        endingInside.add(markerId)
+        endingInsideSplice.add(markerId)
       }
     })
 
-    this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInside, endingInside)
+    this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
   }
 
   getStartingAndEndingMarkersWithinSubtree (node, startMarkerIds, endMarkerIds) {

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -151,11 +151,8 @@ export default class MarkerIndex {
 
     let startingInsideSplice = new Set
     let endingInsideSplice = new Set
-    if (startNode.right) {
-      this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
-      startNode.right = null
-    }
 
+    this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
     if (!isInsertion) {
       startNode.startMarkerIds.forEach(markerId => {
         if (this.isExclusive(markerId)) {
@@ -200,6 +197,7 @@ export default class MarkerIndex {
 
     this.populateSpliceInvalidationSets(invalidated, startNode, endNode, startingInsideSplice, endingInsideSplice, isInsertion)
 
+    startNode.right = null
     endNode.leftExtent = traverse(start, newExtent)
 
     if (compare(startNode.leftExtent, endNode.leftExtent) === 0) {
@@ -412,14 +410,12 @@ export default class MarkerIndex {
   }
 
   getStartingAndEndingMarkersWithinSubtree (node, startMarkerIds, endMarkerIds) {
+    if (node == null) return
+
     addToSet(startMarkerIds, node.startMarkerIds)
     addToSet(endMarkerIds, node.endMarkerIds)
-    if (node.left) {
-      this.getStartingAndEndingMarkersWithinSubtree(node.left, startMarkerIds, endMarkerIds)
-    }
-    if (node.right) {
-      this.getStartingAndEndingMarkersWithinSubtree(node.right, startMarkerIds, endMarkerIds)
-    }
+    this.getStartingAndEndingMarkersWithinSubtree(node.left, startMarkerIds, endMarkerIds)
+    this.getStartingAndEndingMarkersWithinSubtree(node.right, startMarkerIds, endMarkerIds)
   }
 
   populateSpliceInvalidationSets (invalidated, startNode, endNode, startingInsideSplice, endingInsideSplice, isInsertion) {

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -154,20 +154,23 @@ export default class MarkerIndex {
     } else {
       this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
 
-      startingInsideSplice.forEach(markerId => {
-        endNode.startMarkerIds.add(markerId)
-        this.startNodesById[markerId] = endNode
-        if (this.isExclusive(markerId) && endNode.endMarkerIds.has(markerId)) {
-          endingInsideSplice.add(markerId)
-        }
-      })
-
       endingInsideSplice.forEach(markerId => {
         endNode.endMarkerIds.add(markerId)
         if (!startingInsideSplice.has(markerId)) {
           startNode.rightMarkerIds.add(markerId)
         }
         this.endNodesById[markerId] = endNode
+      })
+
+      endNode.endMarkerIds.forEach(markerId => {
+        if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
+          endingInsideSplice.add(markerId)
+        }
+      })
+
+      startingInsideSplice.forEach(markerId => {
+        endNode.startMarkerIds.add(markerId)
+        this.startNodesById[markerId] = endNode
       })
 
       startNode.startMarkerIds.forEach(markerId => {
@@ -177,12 +180,6 @@ export default class MarkerIndex {
           endNode.startMarkerIds.add(markerId)
           this.startNodesById[markerId] = endNode
           startingInsideSplice.add(markerId)
-        }
-      })
-
-      endNode.endMarkerIds.forEach(markerId => {
-        if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
-          endingInsideSplice.add(markerId)
         }
       })
     }

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -387,25 +387,25 @@ export default class MarkerIndex {
 
   getMarkersBetweenNodes (startNode, endNode, startingInside, endingInside) {
     startNode.startMarkerIds.forEach(markerId => {
-      if (this.isExclusive(markerId)) {
+      if (this.isExclusive(markerId) && !startNode.endMarkerIds.has(markerId)) {
         startingInside.add(markerId)
       }
     })
 
     endNode.startMarkerIds.forEach(markerId => {
-      if (!this.isExclusive(markerId) || endNode.endMarkerIds.has(markerId)) {
+      if (!this.isExclusive(markerId)) {
         startingInside.add(markerId)
       }
     })
 
     startNode.endMarkerIds.forEach(markerId => {
-      if (!this.isExclusive(markerId) || startNode.startMarkerIds.has(markerId)) {
+      if (!this.isExclusive(markerId)) {
         endingInside.add(markerId)
       }
     })
 
     endNode.endMarkerIds.forEach(markerId => {
-      if (this.isExclusive(markerId)) {
+      if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
         endingInside.add(markerId)
       }
     })

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -427,9 +427,7 @@ export default class MarkerIndex {
     addToSet(invalidated.touch, endNode.startMarkerIds)
     startNode.rightMarkerIds.forEach((markerId) => {
       invalidated.touch.add(markerId)
-      if (!this.isExclusive(markerId) || !startNode.startMarkerIds.has(markerId) || !endNode.endMarkerIds.has(markerId)) {
-        invalidated.inside.add(markerId)
-      }
+      invalidated.inside.add(markerId)
     })
     endNode.leftMarkerIds.forEach(function (markerId) {
       invalidated.touch.add(markerId)

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -149,10 +149,9 @@ export default class MarkerIndex {
       })
     }
 
-    let startingInsideSplice, endingInsideSplice
+    let startingInsideSplice = new Set
+    let endingInsideSplice = new Set
     if (startNode.right) {
-      startingInsideSplice = new Set
-      endingInsideSplice = new Set
       this.getStartingAndEndingMarkersWithinSubtree(startNode.right, startingInsideSplice, endingInsideSplice)
     }
 
@@ -410,17 +409,31 @@ export default class MarkerIndex {
       invalidated.touch.add(markerId)
       invalidated.inside.add(markerId)
     })
-    if (startingInsideSplice && endingInsideSplice) {
-      startingInsideSplice.forEach(function (markerId) {
-        invalidated.touch.add(markerId)
-        invalidated.inside.add(markerId)
+    startingInsideSplice.forEach(function (markerId) {
+      invalidated.touch.add(markerId)
+      invalidated.inside.add(markerId)
+      invalidated.overlap.add(markerId)
+      if (endingInsideSplice.has(markerId)) invalidated.surround.add(markerId)
+    })
+    endingInsideSplice.forEach(function (markerId) {
+      invalidated.touch.add(markerId)
+      invalidated.inside.add(markerId)
+      invalidated.overlap.add(markerId)
+    })
+
+    if (!isInsertion) {
+      startNode.startMarkerIds.forEach(markerId => {
+        if (!this.isExclusive(markerId)) return
+
         invalidated.overlap.add(markerId)
-        if (endingInsideSplice.has(markerId)) invalidated.surround.add(markerId)
+        if (endingInsideSplice.has(markerId) || endNode.endMarkerIds.has(markerId)) invalidated.surround.add(markerId)
       })
-      endingInsideSplice.forEach(function (markerId) {
-        invalidated.touch.add(markerId)
-        invalidated.inside.add(markerId)
+
+      endNode.endMarkerIds.forEach(markerId => {
+        if (!this.isExclusive(markerId)) return
+
         invalidated.overlap.add(markerId)
+        if (startingInsideSplice.has(markerId) || startNode.startMarkerIds.has(markerId)) invalidated.surround.add(markerId)
       })
     }
   }

--- a/src/js/marker-index.js
+++ b/src/js/marker-index.js
@@ -180,22 +180,6 @@ export default class MarkerIndex {
         }
       })
 
-      endNode.startMarkerIds.forEach(markerId => {
-        if (!this.isExclusive(markerId)) {
-          startingInsideSplice.add(markerId)
-        }
-      })
-
-      startNode.endMarkerIds.forEach(markerId => {
-        if (!this.isExclusive(markerId)) {
-          startNode.endMarkerIds.delete(markerId)
-          endNode.endMarkerIds.add(markerId)
-          startNode.rightMarkerIds.add(markerId)
-          this.endNodesById[markerId] = endNode
-          endingInsideSplice.add(markerId)
-        }
-      })
-
       endNode.endMarkerIds.forEach(markerId => {
         if (this.isExclusive(markerId) && !endNode.startMarkerIds.has(markerId)) {
           endingInsideSplice.add(markerId)

--- a/src/native/marker-index.cc
+++ b/src/native/marker-index.cc
@@ -99,6 +99,9 @@ SpliceResult MarkerIndex::Splice(Point start, Point old_extent, Point new_extent
   end_node->priority = -2;
   BubbleNodeUp(end_node);
 
+  unordered_set<MarkerId> starting_inside_splice;
+  unordered_set<MarkerId> ending_inside_splice;
+
   if (is_insertion) {
     for (auto iter = start_node->start_marker_ids.begin(); iter != start_node->start_marker_ids.end();) {
       MarkerId id = *iter;
@@ -124,31 +127,29 @@ SpliceResult MarkerIndex::Splice(Point start, Point old_extent, Point new_extent
         ++iter;
       }
     }
-  }
+  } else {
+    GetMarkersBetweenNodes(start_node, end_node, &starting_inside_splice, &ending_inside_splice);
 
-  unordered_set<MarkerId> starting_inside_splice;
-  unordered_set<MarkerId> ending_inside_splice;
-
-  if (start_node->right) {
-    GetStartingAndEndingMarkersWithinSubtree(start_node->right, &starting_inside_splice, &ending_inside_splice);
-  }
-
-  PopulateSpliceInvalidationSets(&invalidated, start_node, end_node, starting_inside_splice, ending_inside_splice, is_insertion);
-
-  if (start_node->right) {
     for (MarkerId id : starting_inside_splice) {
+      start_node->start_marker_ids.erase(id);
+      start_node->right_marker_ids.erase(id);
       end_node->start_marker_ids.insert(id);
       start_nodes_by_id[id] = end_node;
     }
 
     for (MarkerId id : ending_inside_splice) {
+      start_node->end_marker_ids.erase(id);
       end_node->end_marker_ids.insert(id);
       if (starting_inside_splice.count(id) == 0) {
         start_node->right_marker_ids.insert(id);
       }
       end_nodes_by_id[id] = end_node;
     }
+  }
 
+  PopulateSpliceInvalidationSets(&invalidated, start_node, end_node, starting_inside_splice, ending_inside_splice);
+
+  if (start_node->right) {
     DeleteSubtree(start_node->right);
     start_node->right = nullptr;
   }
@@ -408,26 +409,52 @@ void MarkerIndex::RotateNodeRight(Node *rotation_pivot) {
   }
 }
 
-void MarkerIndex::GetStartingAndEndingMarkersWithinSubtree(const Node *node, unordered_set<MarkerId> *starting, unordered_set<MarkerId> *ending) {
-  starting->insert(node->start_marker_ids.begin(), node->start_marker_ids.end());
-  ending->insert(node->end_marker_ids.begin(), node->end_marker_ids.end());
-  if (node->left) {
-    GetStartingAndEndingMarkersWithinSubtree(node->left, starting, ending);
+void MarkerIndex::GetMarkersBetweenNodes(const Node *start_node, const Node *end_node, unordered_set<MarkerId> *starting_inside_splice, unordered_set<MarkerId> *ending_inside_splice) {
+  for (MarkerId id : start_node->start_marker_ids) {
+    if (exclusive_marker_ids.count(id) && !start_node->end_marker_ids.count(id)) {
+      starting_inside_splice->insert(id);
+    }
   }
-  if (node->right) {
-    GetStartingAndEndingMarkersWithinSubtree(node->right, starting, ending);
+
+  for (MarkerId id : end_node->start_marker_ids) {
+    if (!exclusive_marker_ids.count(id)) {
+      starting_inside_splice->insert(id);
+    }
   }
+
+  for (MarkerId id : start_node->end_marker_ids) {
+    if (!exclusive_marker_ids.count(id)) {
+      ending_inside_splice->insert(id);
+    }
+  }
+
+  for (MarkerId id : end_node->end_marker_ids) {
+    if (exclusive_marker_ids.count(id) && !end_node->start_marker_ids.count(id)) {
+      ending_inside_splice->insert(id);
+    }
+  }
+
+  GetStartingAndEndingMarkersWithinSubtree(start_node->right, starting_inside_splice, ending_inside_splice);
 }
 
-void MarkerIndex::PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const unordered_set<MarkerId> &starting_inside_splice, const unordered_set<MarkerId> &ending_inside_splice, bool is_insertion) {
+void MarkerIndex::GetStartingAndEndingMarkersWithinSubtree(const Node *node, unordered_set<MarkerId> *starting, unordered_set<MarkerId> *ending) {
+  if (node == nullptr) {
+    return;
+  }
+
+  GetStartingAndEndingMarkersWithinSubtree(node->left, starting, ending);
+  starting->insert(node->start_marker_ids.begin(), node->start_marker_ids.end());
+  ending->insert(node->end_marker_ids.begin(), node->end_marker_ids.end());
+  GetStartingAndEndingMarkersWithinSubtree(node->right, starting, ending);
+}
+
+void MarkerIndex::PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const unordered_set<MarkerId> &starting_inside_splice, const unordered_set<MarkerId> &ending_inside_splice) {
   invalidated->touch.insert(start_node->end_marker_ids.begin(), start_node->end_marker_ids.end());
   invalidated->touch.insert(end_node->start_marker_ids.begin(), end_node->start_marker_ids.end());
 
   for (MarkerId id : start_node->right_marker_ids) {
     invalidated->touch.insert(id);
-    if (!(is_insertion && (start_node->start_marker_ids.count(id) > 0 || end_node->end_marker_ids.count(id) > 0))) {
-      invalidated->inside.insert(id);
-    }
+    invalidated->inside.insert(id);
   }
 
   for (MarkerId id : end_node->left_marker_ids) {
@@ -446,21 +473,5 @@ void MarkerIndex::PopulateSpliceInvalidationSets(SpliceResult *invalidated, cons
     invalidated->touch.insert(id);
     invalidated->inside.insert(id);
     invalidated->overlap.insert(id);
-  }
-
-  if (!is_insertion) {
-    for (MarkerId id : start_node->start_marker_ids) {
-      if (exclusive_marker_ids.count(id)) {
-        invalidated->overlap.insert(id);
-        if (ending_inside_splice.count(id) || end_node->end_marker_ids.count(id)) invalidated->surround.insert(id);
-      }
-    }
-
-    for (MarkerId id : end_node->end_marker_ids) {
-      if (exclusive_marker_ids.count(id)) {
-        invalidated->overlap.insert(id);
-        if (starting_inside_splice.count(id) || start_node->start_marker_ids.count(id)) invalidated->surround.insert(id);
-      }
-    }
   }
 }

--- a/src/native/marker-index.cc
+++ b/src/native/marker-index.cc
@@ -447,4 +447,20 @@ void MarkerIndex::PopulateSpliceInvalidationSets(SpliceResult *invalidated, cons
     invalidated->inside.insert(id);
     invalidated->overlap.insert(id);
   }
+
+  if (!is_insertion) {
+    for (MarkerId id : start_node->start_marker_ids) {
+      if (exclusive_marker_ids.count(id)) {
+        invalidated->overlap.insert(id);
+        if (ending_inside_splice.count(id) || end_node->end_marker_ids.count(id)) invalidated->surround.insert(id);
+      }
+    }
+
+    for (MarkerId id : end_node->end_marker_ids) {
+      if (exclusive_marker_ids.count(id)) {
+        invalidated->overlap.insert(id);
+        if (starting_inside_splice.count(id) || start_node->start_marker_ids.count(id)) invalidated->surround.insert(id);
+      }
+    }
+  }
 }

--- a/src/native/marker-index.h
+++ b/src/native/marker-index.h
@@ -40,8 +40,9 @@ class MarkerIndex {
   void BubbleNodeDown(Node *node);
   void RotateNodeLeft(Node *pivot);
   void RotateNodeRight(Node *pivot);
+  void GetMarkersBetweenNodes(const Node *start_node, const Node *end_node, std::unordered_set<MarkerId> *starting_inside_splice, std::unordered_set<MarkerId> *ending_inside_splice);
   void GetStartingAndEndingMarkersWithinSubtree(const Node *node, std::unordered_set<MarkerId> *starting, std::unordered_set<MarkerId> *ending);
-  void PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const std::unordered_set<MarkerId> &starting_inside_splice, const std::unordered_set<MarkerId> &ending_inside_splice, bool is_insertion);
+  void PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const std::unordered_set<MarkerId> &starting_inside_splice, const std::unordered_set<MarkerId> &ending_inside_splice);
 
   std::default_random_engine random_engine;
   std::uniform_int_distribution<int> random_distribution;

--- a/src/native/marker-index.h
+++ b/src/native/marker-index.h
@@ -40,7 +40,6 @@ class MarkerIndex {
   void BubbleNodeDown(Node *node);
   void RotateNodeLeft(Node *pivot);
   void RotateNodeRight(Node *pivot);
-  void GetMarkersBetweenNodes(const Node *start_node, const Node *end_node, std::unordered_set<MarkerId> *starting_inside_splice, std::unordered_set<MarkerId> *ending_inside_splice);
   void GetStartingAndEndingMarkersWithinSubtree(const Node *node, std::unordered_set<MarkerId> *starting, std::unordered_set<MarkerId> *ending);
   void PopulateSpliceInvalidationSets(SpliceResult *invalidated, const Node *start_node, const Node *end_node, const std::unordered_set<MarkerId> &starting_inside_splice, const std::unordered_set<MarkerId> &ending_inside_splice);
 

--- a/test/marker-index.test.js
+++ b/test/marker-index.test.js
@@ -353,19 +353,19 @@ for (let [name, MarkerIndex] of [['js', JSMarkerIndex], ['native', NativeMarkerI
           let isEmpty = compare(marker.start, marker.end) === 0
 
           if (compare(spliceStart, marker.end) <= 0 && compare(marker.start, spliceOldEnd) <= 0) {
-            let spliceIntersectsMarker, markerStartsWithinSplice, markerEndsWithinSplice
+            let markerStartsWithinSplice, markerEndsWithinSplice
+            let spliceIntersectsMarker = compare(spliceStart, marker.end) < 0 && compare(spliceOldEnd, marker.start) > 0
+
             if (marker.exclusive) {
-              spliceIntersectsMarker = compare(spliceStart, marker.end) < 0 && compare(spliceOldEnd, marker.start) > 0
               markerStartsWithinSplice =
-                compare(spliceOldEnd, marker.start) > 0 &&
-                (compare(spliceStart, marker.start) < 0 || (!isEmpty && compare(spliceStart, marker.start) === 0))
+                (compare(spliceStart, marker.start) < 0 || (!isEmpty && compare(spliceStart, marker.start) === 0)) &&
+                  compare(spliceOldEnd, marker.start) > 0
               markerEndsWithinSplice =
                 compare(spliceStart, marker.end) < 0 &&
-                (compare(spliceOldEnd, marker.end) > 0 || (!isEmpty && compare(spliceOldEnd, marker.end) === 0))
+                  (compare(spliceOldEnd, marker.end) > 0 || (!isEmpty && compare(spliceOldEnd, marker.end) === 0))
             } else {
-              spliceIntersectsMarker = true
-              markerStartsWithinSplice = compare(spliceStart, marker.start) < 0 && compare(marker.start, spliceOldEnd) <= 0
-              markerEndsWithinSplice = compare(spliceStart, marker.end) <= 0 && compare(marker.end, spliceOldEnd) < 0
+              markerStartsWithinSplice = compare(spliceStart, marker.start) < 0 && compare(marker.start, spliceOldEnd) < 0
+              markerEndsWithinSplice = compare(spliceStart, marker.end) < 0 && compare(marker.end, spliceOldEnd) < 0
             }
 
             invalidated.touch.add(marker.id)
@@ -387,7 +387,7 @@ for (let [name, MarkerIndex] of [['js', JSMarkerIndex], ['native', NativeMarkerI
           let moveMarkerEnd =
             moveMarkerStart ||
               (compare(spliceStart, marker.end) < 0) ||
-                (!marker.exclusive && compare(spliceStart, marker.end) === 0)
+                (!marker.exclusive && compare(spliceOldEnd, marker.end) === 0)
 
           if (moveMarkerStart) {
             if (compare(spliceOldEnd, marker.start) <= 0) { // splice precedes marker start

--- a/test/marker-index.test.js
+++ b/test/marker-index.test.js
@@ -355,9 +355,13 @@ for (let [name, MarkerIndex] of [['js', JSMarkerIndex], ['native', NativeMarkerI
           if (compare(spliceStart, marker.end) <= 0 && compare(marker.start, spliceOldEnd) <= 0) {
             let spliceIntersectsMarker, markerStartsWithinSplice, markerEndsWithinSplice
             if (marker.exclusive) {
-              spliceIntersectsMarker = (isEmpty && !isInsertion) || (compare(spliceStart, marker.end) < 0 && compare(spliceOldEnd, marker.start) > 0)
-              markerStartsWithinSplice = (isEmpty && !isInsertion) || (compare(spliceStart, marker.start) <= 0 && compare(marker.start, spliceOldEnd) < 0)
-              markerEndsWithinSplice = (isEmpty && !isInsertion) || (compare(spliceStart, marker.end) < 0 && compare(marker.end, spliceOldEnd) <= 0)
+              spliceIntersectsMarker = compare(spliceStart, marker.end) < 0 && compare(spliceOldEnd, marker.start) > 0
+              markerStartsWithinSplice =
+                compare(spliceOldEnd, marker.start) > 0 &&
+                (compare(spliceStart, marker.start) < 0 || (!isEmpty && compare(spliceStart, marker.start) === 0))
+              markerEndsWithinSplice =
+                compare(spliceStart, marker.end) < 0 &&
+                (compare(spliceOldEnd, marker.end) > 0 || (!isEmpty && compare(spliceOldEnd, marker.end) === 0))
             } else {
               spliceIntersectsMarker = true
               markerStartsWithinSplice = compare(spliceStart, marker.start) < 0 && compare(marker.start, spliceOldEnd) <= 0
@@ -378,12 +382,12 @@ for (let [name, MarkerIndex] of [['js', JSMarkerIndex], ['native', NativeMarkerI
 
           let moveMarkerStart =
             (compare(spliceStart, marker.start) < 0) ||
-            (marker.exclusive && (compare(spliceStart, marker.start) === 0 || compare(spliceOldEnd, marker.start) === 0))
+              (marker.exclusive && (!isEmpty || isInsertion) && compare(spliceStart, marker.start) === 0)
 
           let moveMarkerEnd =
-            compare(spliceStart, marker.end) < 0 ||
-            (moveMarkerStart && isEmpty) ||
-            (!marker.exclusive && (compare(spliceStart, marker.end) === 0 || compare(spliceOldEnd, marker.end) === 0))
+            moveMarkerStart ||
+              (compare(spliceStart, marker.end) < 0) ||
+                (!marker.exclusive && compare(spliceStart, marker.end) === 0)
 
           if (moveMarkerStart) {
             if (compare(spliceOldEnd, marker.start) <= 0) { // splice precedes marker start

--- a/test/marker-index.test.js
+++ b/test/marker-index.test.js
@@ -353,8 +353,8 @@ for (let [name, MarkerIndex] of [['js', JSMarkerIndex], ['native', NativeMarkerI
           let isEmpty = compare(marker.start, marker.end) === 0
 
           if (compare(spliceStart, marker.end) <= 0 && compare(marker.start, spliceOldEnd) <= 0) {
+            let invalidateInside = compare(spliceStart, marker.end) < 0 && compare(spliceOldEnd, marker.start) > 0
             let markerStartsWithinSplice, markerEndsWithinSplice
-            let spliceIntersectsMarker = compare(spliceStart, marker.end) < 0 && compare(spliceOldEnd, marker.start) > 0
 
             if (marker.exclusive) {
               markerStartsWithinSplice =
@@ -364,12 +364,13 @@ for (let [name, MarkerIndex] of [['js', JSMarkerIndex], ['native', NativeMarkerI
                 compare(spliceStart, marker.end) < 0 &&
                   (compare(spliceOldEnd, marker.end) > 0 || (!isEmpty && compare(spliceOldEnd, marker.end) === 0))
             } else {
+              invalidateInside = invalidateInside || ((!isEmpty || isInsertion) && (compare(spliceStart, marker.start) === 0 || compare(spliceOldEnd, marker.end) === 0))
               markerStartsWithinSplice = compare(spliceStart, marker.start) < 0 && compare(marker.start, spliceOldEnd) < 0
               markerEndsWithinSplice = compare(spliceStart, marker.end) < 0 && compare(marker.end, spliceOldEnd) < 0
             }
 
             invalidated.touch.add(marker.id)
-            if (spliceIntersectsMarker) {
+            if (invalidateInside) {
               invalidated.inside.add(marker.id)
             }
             if (markerStartsWithinSplice || markerEndsWithinSplice) {


### PR DESCRIPTION
When the index is spliced and the region surrounds/overlaps the marker's start/end, we consider it as invalid. A little nuance here is that we don't cover markers that start or end exactly at the spliced region. This causes an issue in atom/atom#11414, where deleting a folded region doesn't cause the corresponding marker to be invalidated:

![delete-folded-region](https://cloud.githubusercontent.com/assets/482957/14424857/b6b095c4-ffe3-11e5-8c8b-3702601e6e24.gif)

Folds, however, are exclusive markers: this means that if the spliced region completely covers the fold, we should assume that its start and end are inside such region as well, thus reporting the corresponding marker in the appropriate invalidated set.

With this PR we provide an implementation of the algorithm described above: in fact, when we're not performing an insertion and an exclusive marker starts and/or ends exactly at the spliced boundaries, we include it in the `surround` and/or `overlap` set(s) of invalidated markers.

/cc: @nathansobo