### PR TITLE
Convert std::unordered_set to v8::Set via native APIs

### DIFF
--- a/src/native/marker-index-wrapper.cc
+++ b/src/native/marker-index-wrapper.cc
@@ -136,14 +136,17 @@ private:
     return result;
   }
 
-  static Local<Object> MarkerIdsToJS(const unordered_set<MarkerId> &marker_ids) {
-    Local<Object> js_set = Nan::To<Object>(Nan::New(set_constructor)->CallAsConstructor(0, nullptr)).ToLocalChecked();
-    Local<Object> set_add_method_local = Nan::New(set_add_method);
+  static Local<Set> MarkerIdsToJS(const unordered_set<MarkerId> &marker_ids) {
+    Isolate *isolate = v8::Isolate::GetCurrent();
+    Local<Context> context = isolate->GetCurrentContext();
+    Local<v8::Set> js_set = v8::Set::New(isolate);
 
     for (MarkerId id : marker_ids) {
-      Local<Value> argv[] {Nan::New<Integer>(id)};
-      set_add_method_local->CallAsFunction(js_set, 1, argv);
+      // Not sure why Set::Add warns if we don't use its return value, but
+      // just doing it to avoid the warning.
+      js_set = js_set->Add(context, Nan::New<Integer>(id)).ToLocalChecked();
     }
+
     return js_set;
   }
 


### PR DESCRIPTION
This API didn’t exist when we originally wrote the native implementation of this module.

The benchmarks with 3 trials show a modest improvement over the previous solution that involved invoking methods on the JS objects from C++. About 7% faster for my tests in splices. Not that great honestly but it's still nice to use the proper API now that it exists.

We should probably perform a native trace if we want more performance, but I suspect populating v8 sets in the actual algorithm rather than bailing everything over in the wrapper might yield better performance. We probably have bigger fish to fry right now however.

Before this PR:

inserts: 186.765ms, 181.718ms, 178.908ms
rangeQueries: 754.014ms, 756.123ms, 741.803ms
splices: 6121.944ms, 6330.046ms, 5959.000ms
deletes: 64.560ms, 68.375ms, 66.130ms

After this PR:

inserts: 174.896ms, 173.341ms, 167.472ms
rangeQueries: 712.952ms, 730.542ms, 711.279ms
splices: 5635.677ms, 5804.875ms, 5739.785ms -- 5726.778
deletes: 70.311ms, 66.241ms, 65.933ms

/cc @as-cii 